### PR TITLE
Add instructions for Apache2 using PHP FPM

### DIFF
--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -171,7 +171,16 @@ Example:
  </Directory>
  [...]
 
+If you are using PHP-FPM you need to disable fcgi cache for the screen module to work correctly. Add the following to VirtualHost section:
+::
 
+ [...]
+ <Proxy "fcgi://localhost/">
+        ProxySet flushpackets=on
+ </Proxy>
+ [...]
+ 
+See `mod_proxy documentation <https://httpd.apache.org/docs/2.4/mod/mod_proxy.html#proxypass>`_ for more details.
 
 Stable version
 """""""""""""""""


### PR DESCRIPTION
When using Apache2 with PHP FPM instead of the PHP module, the Screen app will only work when disabling the fcgi "cache". Added the relevant configuration to the apache2 section of the document.